### PR TITLE
Fix template env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,4 +30,4 @@ DISCORD_BOT_TOKEN=""
 DISCORD_PUBLIC_KEY=""
 
 # An allowed Discord account to login successfully
-ADMIN_ID=""
+ADMIN_DISCORD_ID=""


### PR DESCRIPTION
You use `ADMIN_DISCORD_ID` in code but on the example env it uses `ADMIN_ID`

credit: @DuckyProgrammer / DuckyProgrammer#7411 